### PR TITLE
 Adición de referencia a tabla de simbolos global en clase Arbol

### DIFF
--- a/src/arbol/Arbol.java
+++ b/src/arbol/Arbol.java
@@ -22,7 +22,7 @@ public class Arbol implements Instruccion{
     /**
      * Variable correspondiente a la instancia de la tabla de simbolos global que podrá ser accedida por cualquier función interpretada.
      */
-    public static TablaDeSimbolos tablaDeSimbolosGlobal;
+    public TablaDeSimbolos tablaDeSimbolosGlobal;
     
     /**
      * Constructor de la clase Arbol

--- a/src/arbol/Arbol.java
+++ b/src/arbol/Arbol.java
@@ -17,6 +17,13 @@ public class Arbol implements Instruccion{
      * Lista de las instrucciones (Funciones y declaraciones de variables globales) que componen el archivo.
      */
     private final LinkedList<Instruccion> instrucciones;
+    
+    
+    /**
+     * Variable correspondiente a la instancia de la tabla de simbolos global que podrá ser accedida por cualquier función interpretada.
+     */
+    public static TablaDeSimbolos tablaDeSimbolosGlobal;
+    
     /**
      * Constructor de la clase Arbol
      * @param a Lista de instrucciones que conforman al Arbol
@@ -33,6 +40,9 @@ public class Arbol implements Instruccion{
      */    
     @Override
     public Object ejecutar(TablaDeSimbolos ts,Arbol ar) {
+        
+        tablaDeSimbolosGlobal = ts;
+        
         for(Instruccion ins:instrucciones){
             if(ins instanceof Declaracion){
                 Declaracion d=(Declaracion)ins;


### PR DESCRIPTION
Se agregó una referencia estática a la tabla de simbolos global en la clase **Arbol** para que pueda ser accedida desde cualquier subinstruccion.

Carné: 201503748