### PR TITLE
Sobrecarga de funciones | 200815284

### DIFF
--- a/entrada_sobrecarga_de_funciones.txt
+++ b/entrada_sobrecarga_de_funciones.txt
@@ -1,0 +1,40 @@
+/******************************************
+ * Ejemplo desarrollado por Erick Navarro *
+ * Blog: e-navarro.blogspot.com           *
+ * Enero - 2019                           *
+ ******************************************/
+
+Declare Number a;
+Declare Number b;
+
+Function Void main(){
+	Print("Prueba de metodos con el mismo nombre y diferentes parametros");
+	Contar(4);
+	Contar(2, 4);
+
+	Saludar("Rainman");
+	Saludar("Rainman", "Sian");
+	Saludar("Rainman", 30);
+
+	Print("Esto es el final de la prueba");
+}
+
+Function Void Contar(Number hasta) {
+	Print("Contando desde 1.0 hasta " & hasta);
+}
+
+Function Void Contar(Number desde, Number hasta) {
+	Print("Contando desde " & desde & " hasta " & hasta);
+}
+
+Function Void Saludar(String nombre) {
+	Print("Hola " & nombre);
+}
+
+Function Void Saludar(String nombre, Number edad) {
+	Print("Hola " & nombre & " de " & edad & " anios de edad");
+}
+
+Function Void Saludar(String nombre, String apellido) {
+	Print("Hola " & nombre & " " & apellido);
+}

--- a/src/arbol/Arbol.java
+++ b/src/arbol/Arbol.java
@@ -53,7 +53,8 @@ public class Arbol implements Instruccion{
             if(ins instanceof Function){
                 Function f=(Function)ins;
                 String id=f.getIdentificador();
-                if("main".equals(id)){
+                // el identificador único de la función main es _main() ya que no recibe parámetros
+                if("_main()".equals(id)){
                     f.setValoresParametros(new LinkedList<>());
                     f.ejecutar(ts, ar);
                     break;
@@ -74,7 +75,7 @@ public class Arbol implements Instruccion{
             if(ins instanceof Function){
                 Function f=(Function)ins;
                 String id=f.getIdentificador();
-                if(identificador.toLowerCase().equals(id)){
+                if(identificador.equals(id)){
                     return f;
                 }
             }

--- a/src/arbol/Function.java
+++ b/src/arbol/Function.java
@@ -126,7 +126,19 @@ public class Function implements Instruccion {
      * @return Identificador de la función
      */
     public String getIdentificador() {
-        return identificador.toLowerCase();
+
+        // se crea un identificador único de las funciones con base en su Id 
+        // más el tipo de sus parametros de la forma _id(_tipo..._tipo)
+
+        String id = "_" + identificador + "(";
+        if (parametros != null) {
+            for (Declaracion parametro: parametros) {
+                id += "_" + parametro.tipo.name();
+            }
+        }
+        id += ")";
+        
+        return id.toLowerCase();
     }
     /**
      * Método que configura el set de parámetros que la función debe recibir

--- a/src/arbol/LlamadaFuncion.java
+++ b/src/arbol/LlamadaFuncion.java
@@ -41,7 +41,31 @@ public class LlamadaFuncion implements Instruccion{
      */
     @Override
     public Object ejecutar(TablaDeSimbolos ts,Arbol ar) {
-        Function f=ar.getFunction(identificador);
+        
+        // creando identificador único
+        int numParametros = 0;
+        if (parametros != null) {
+            numParametros = parametros.size();
+        }
+        
+        // para llamar a la función es necesario construir su identificador único
+        String id = "_" + identificador + "(";
+        for(Instruccion parametro: parametros) {
+            // es necesario evaluar los parametros de la función para saber sus tipo
+            // y así poder completar el id
+            Object resultado = parametro.ejecutar(ts, ar);
+            
+            if (resultado instanceof Double) {
+                id += "_" + Simbolo.Tipo.NUMERO;
+            } else if(resultado instanceof String) {
+                id += "_" + Simbolo.Tipo.CADENA;
+            } else if(resultado instanceof Boolean){
+                id += "_" + Simbolo.Tipo.BOOLEANO;
+            }
+        }
+        id += ")";
+        
+        Function f=ar.getFunction(id.toLowerCase());
         if(null!=f){
             f.setValoresParametros(parametros);
             return f.ejecutar(ts, ar);


### PR DESCRIPTION
Actualmente la ejecución falla al tener dos funciones con el mismo nombre y diferente número de parametros. Por ejemplo:

`Function Void Contar(Number hasta) { ... }`
`Function Void Contar(Number desde, Number hasta) { ... }`

debido a que las funciones utilizan únicamente su nombre como ID.

Se extiende esto utilizando los tipos de los parametros para poder sobrecargar funciones