### PR TITLE
Error sentencia RETURN para Funciones de tipo VOID

### DIFF
--- a/src/arbol/Arbol.java
+++ b/src/arbol/Arbol.java
@@ -18,7 +18,7 @@ public class Arbol implements Instruccion{
      */
     private final LinkedList<Instruccion> instrucciones;
     
-    
+    private static Simbolo.Tipo tipoFuncionPre;
     /**
      * Variable correspondiente a la instancia de la tabla de simbolos global que podrá ser accedida por cualquier función interpretada.
      */
@@ -40,7 +40,6 @@ public class Arbol implements Instruccion{
      */    
     @Override
     public Object ejecutar(TablaDeSimbolos ts,Arbol ar) {
-        
         tablaDeSimbolosGlobal = ts;
         
         for(Instruccion ins:instrucciones){
@@ -53,6 +52,7 @@ public class Arbol implements Instruccion{
             if(ins instanceof Function){
                 Function f=(Function)ins;
                 String id=f.getIdentificador();
+                //tipoFuncionPre = f.getTipo();
                 if("main".equals(id)){
                     f.setValoresParametros(new LinkedList<>());
                     f.ejecutar(ts, ar);
@@ -74,12 +74,17 @@ public class Arbol implements Instruccion{
             if(ins instanceof Function){
                 Function f=(Function)ins;
                 String id=f.getIdentificador();
+                tipoFuncionPre = f.getTipo();
                 if(identificador.toLowerCase().equals(id)){
                     return f;
                 }
             }
         }
         return null;
+    }
+    
+    public static Simbolo.Tipo getFuncionPre(){
+        return tipoFuncionPre;
     }
     
 }

--- a/src/arbol/Arbol.java
+++ b/src/arbol/Arbol.java
@@ -18,7 +18,7 @@ public class Arbol implements Instruccion{
      */
     private final LinkedList<Instruccion> instrucciones;
     
-    private static Simbolo.Tipo tipoFuncionPre;
+    private Function FunctionPre; // Declaración de variable temporal.
     /**
      * Variable correspondiente a la instancia de la tabla de simbolos global que podrá ser accedida por cualquier función interpretada.
      */
@@ -74,7 +74,7 @@ public class Arbol implements Instruccion{
             if(ins instanceof Function){
                 Function f=(Function)ins;
                 String id=f.getIdentificador();
-                tipoFuncionPre = f.getTipo();
+                FunctionPre = f;// Variable temporal para guardar el objeto de la clase "Function"
                 if(identificador.toLowerCase().equals(id)){
                     return f;
                 }
@@ -83,8 +83,11 @@ public class Arbol implements Instruccion{
         return null;
     }
     
-    public static Simbolo.Tipo getFuncionPre(){
-        return tipoFuncionPre;
+    /*
+        Funcion para retornar un objeto de la clase Function
+    */
+    public Function getFuncionPre(){
+        return FunctionPre;
     }
     
 }

--- a/src/arbol/Function.java
+++ b/src/arbol/Function.java
@@ -136,6 +136,9 @@ public class Function implements Instruccion {
         valoresParametros=a;
     }
     
+    /*
+        Funcion para retornar el tipo de la funcion
+    */
     public Simbolo.Tipo getTipo(){
        return tipo; 
     }

--- a/src/arbol/Function.java
+++ b/src/arbol/Function.java
@@ -136,4 +136,9 @@ public class Function implements Instruccion {
         valoresParametros=a;
     }
     
+    public Simbolo.Tipo getTipo(){
+       return tipo; 
+    }
+
+    
 }

--- a/src/arbol/Return.java
+++ b/src/arbol/Return.java
@@ -36,14 +36,24 @@ public class Return implements Instruccion{
      */    
     @Override
     public Object ejecutar(TablaDeSimbolos ts, Arbol ar) {
+        String tipoFuncion = ar.getFuncionPre().getTipo().toString(); // Get tipo de la funcion
+        String idFuncion = ar.getFuncionPre().getIdentificador().toString(); // Get indentificador de la funcion
         if(valorRetorno==null){
-            if (Arbol.getFuncionPre().toString() != "VOID") {
-                System.err.println("Se tiene que retornar un tipo de datos:" + Arbol.getFuncionPre().toString());
+            /*
+                Condicion cuando el return contiene un dato que retornar
+                se verifica que la funcion no tenga VOID si no salta un error
+            */
+            if (tipoFuncion.toLowerCase().equals("VOID".toLowerCase()) == false) {
+                System.err.println("ERROR:Se tiene que retornar un tipo de variable que indica el retorno la funcion: " + idFuncion);
             }
             return this;
         }else{
-            if (Arbol.getFuncionPre().toString() == "VOID") {
-                System.err.println("No se puede retornar un objeto en un procedimiento");
+            /*
+                Condicion cuando el return NO contiene un dato que retornar
+                se verifica que la funcion TENGA VOID si no salta un error
+             */
+            if (tipoFuncion.toLowerCase().equals("VOID".toLowerCase())) {
+                System.err.println("ERROR:No se puede retornar el tipo de variable dado que la funcion es VOID o equivalente un procedimiento, error en la funcion: "+ idFuncion);
             }
             return valorRetorno.ejecutar(ts, ar);
         }

--- a/src/arbol/Return.java
+++ b/src/arbol/Return.java
@@ -37,8 +37,14 @@ public class Return implements Instruccion{
     @Override
     public Object ejecutar(TablaDeSimbolos ts, Arbol ar) {
         if(valorRetorno==null){
+            if (Arbol.getFuncionPre().toString() != "VOID") {
+                System.err.println("Se tiene que retornar un tipo de datos:" + Arbol.getFuncionPre().toString());
+            }
             return this;
         }else{
+            if (Arbol.getFuncionPre().toString() == "VOID") {
+                System.err.println("No se puede retornar un objeto en un procedimiento");
+            }
             return valorRetorno.ejecutar(ts, ar);
         }
     }


### PR DESCRIPTION
Se modifico para que se muestre un error cuando se retorne  NUMERO,CADENA o BOOLEANO en una función con un retorno vació
Por ejemplo si intentamos lo siguiente del documentos de entrada
Function Void imprimirSet(Number paramSup){
	return 5;
}
esto tiene que dar error, porque se esta intentado retornar un numero en una función que solo acepta un retorno vacio.

Esa modificación se le realizo la código a los archivos
src/arbol/Arbol.java

Dentro de la clase Arbol.java se agrego "private static Simbolo.Tipo tipoFuncionPre;"  para guardar el tipo de retorno que acepta la función, asignado el dato con la siguiente linea tipoFuncionPre = f.getTipo();  dentro de la función "getFunction".

src/arbol/Function.java

se le agrego la función getTipo() para que retornara el tipo de retorno que acepta la función. 

src/arbol/Return.java 

Luego dentro de la clase "Return.java" se hace una condición sabiendo si el Return tiene un dato o esta vació, a base de eso se muestra un error si esta esta intentado retornar un dato en una función que solo acepta retorno VOID.   

Carnet: 200714200
